### PR TITLE
Changed Preprocessor Directive to Avoid Undefined Behavior

### DIFF
--- a/src/ESPMail.h
+++ b/src/ESPMail.h
@@ -25,7 +25,7 @@ along with ESPMail.  If not, see <http://www.gnu.org/licenses/>.
 #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM)
 #include "Arduino.h"
 #include <Client.h>
-#include "libquickmail\quickmail.h"
+#include "libquickmail/quickmail.h"
 #else
 #error Only Arduino MKR1000, Yun, Uno/Mega/Due with either WiFi101 or Ethernet shield. ESP8266 also supported.
 #endif


### PR DESCRIPTION
Hi @grzesl,

I noticed the `#include "libquickmail\quickmail.h"` in  [ESPMail.h](https://github.com/dvigne/ESPMail/blob/ac9c3ca8c6ae9e4a13c10dd20026cdf777386b5e/src/ESPMail.h#L28) used a backslash for what I assume is for Windows path compatibility. This caused a build error and I believe if changed to a forward slash it will allow compatibility across platforms and will build appropriately. As a side note, It is also considered C++98 standard to use a forward slash in source file inclusion preprocessor directives per §2.8.2 of ISO/IEC 14882:1998.

Thanks!